### PR TITLE
Allow scoped packages /size/ endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ function start (id) {
     const query = { style: req.query.style }
     let url
     // Express' path-to-regexp business is too insane to easily do this above.
-    if (path.match(/^\w/)) {
+    if (path.length > 0) {
       if (source === 'github') {
         url = `https://raw.githubusercontent.com/${path}`
       } else if (source === 'npm') {


### PR DESCRIPTION
This PR fixes an issue that disallow us to use the /size/ endpoint with npm scoped packages.
I've completely removed the regex since it was useless.
It only checked if the first character was a word character  [a-zA-Z0-9_].

We can implement a better regex for it but I think that is unnecessary work for the server.
Let me know what you think!


Example of non-working badge:
[![](https://badges.herokuapp.com/size/npm/@geo-maps/countries-maritime-1m/map.geo.json)](https://unpkg.com/@geo-maps/countries-maritime-10km@0.3.0/map.geo.json)