### PR TITLE
Speed up calculation of gzip sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "compression": "^1.6.0",
     "express": "^4.13.3",
     "express-interceptor": "^1.1.1",
-    "gzip-size": "^3.0.0",
+    "gzip-size": "^4.0.0",
     "humanize-duration": "^3.9.1",
     "lodash": "^4.16.0",
     "lru-cache": "^4.0.1",

--- a/src/cached-request.js
+++ b/src/cached-request.js
@@ -2,6 +2,7 @@ import request from 'request'
 import LRU from 'lru-cache'
 import hash from 'object-hash'
 import humanizeDuration from 'humanize-duration'
+import gzipSize from 'gzip-size'
 import { prettyPrint } from './util'
 
 export const ONE_MINUTE = 60 * 1000
@@ -36,16 +37,45 @@ export default function cachedRequest (url, options, customTTL) {
   }
   console.log(`Cache miss: ${url}`)
   promise = new Promise((resolve, reject) => {
-    request({ ...options, url }, (err, response, body) => {
+    const { size = false, ...requestOptions } = options
+    const gzip = options.gzip || false
+    let responseDataSize = 0
+    request({ ...requestOptions, url }, (err, response, body) => {
       if (err) {
         reject(err)
       } else if (response.statusCode >= 400) {
         err = new Error(`HTTP ${response.statusCode}`)
         err.response = response
         reject(err)
+      } else if (size) {
+        const isGzipResponse = response.headers['content-encoding'] === 'gzip'
+        if (gzip === isGzipResponse && response.headers['content-length']) {
+          console.log('Size request: returning Content-Length.')
+          resolve(parseInt(response.headers['content-length'], 10))
+        } else if (method === 'HEAD') {
+          console.log('Size request made with HEAD, but no Content-Length: returning null.')
+          resolve(null)
+        } else if (gzip) {
+          if (isGzipResponse) {
+            console.log('Size request received gzip: returning raw response size.')
+            resolve(responseDataSize)
+          } else {
+            console.log('Size request received uncompressed data: running gzip.')
+            resolve(gzipSize(body))
+          }
+        } else {
+          console.log('Size request: returning body length.')
+          resolve(body.length)
+        }
+      } else if (resolveHeaders) {
+        resolve(response.headers)
       } else {
-        resolve(resolveHeaders ? response.headers : body)
+        resolve(body)
       }
+    }).on('response', response => {
+      response.on('data', data => {
+        responseDataSize += data.length
+      })
     })
   })
   // Give the caller an opportunity to change the `maxAge` of the cached item.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,11 +1951,12 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-gzip-size@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+gzip-size@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.0.0.tgz#a80e13e18938bcb2e6702fec606f5cf8b666db3a"
   dependencies:
     duplexer "^0.1.1"
+    pify "^3.0.0"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -2916,6 +2917,10 @@ performance-now@^0.2.0:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This speeds up calculation of gzip sizes for large files (like in @simonepri's example in #16) by adding a counter for the raw response size in `cachedRequest`.

This way, if we receive a gzipped response, and there is no `Content-Length` header, we can just return the size of the server's raw response data instead of always gzipping the response body ourselves, offloading the compression work onto the origin server. The only time we'll gzip files ourselves now is if the origin server decided not to compress it.

/cc @simonepri 